### PR TITLE
feat: org プロフィール README と共有設定を追加

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+buy_me_a_coffee: yetanother_yk
+github: actver-dev

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# .github
+
+[actver-dev](https://github.com/actver-dev) organization の共有設定リポジトリです。
+
+## 含まれるもの
+
+| パス | 説明 |
+|------|------|
+| `profile/README.md` | org プロフィールページ（英語） |
+| `profile/README.ja.md` | org プロフィールページ（日本語） |
+| `.github/FUNDING.yml` | org 全体のデフォルトスポンサー設定 |

--- a/profile/README.ja.md
+++ b/profile/README.ja.md
@@ -1,0 +1,64 @@
+# ActVer
+
+[English](README.md)
+
+[![ActVer](https://img.shields.io/badge/ActVer-actver.dev-blue)](https://actver.dev)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-orange?logo=buy-me-a-coffee&logoColor=white)](https://buymeacoffee.com/yetanother_yk)
+
+**ActVer** は GitHub Actions の最新バージョンとコミット SHA を簡単に取得できる無料サービスです — REST API、MCP サーバー、Web UI を提供しています。
+
+リリースページを探し回る必要はもうありません。1 リクエストで欲しいバージョンが手に入ります。
+
+## 提供しているもの
+
+**[actver.dev](https://actver.dev)** — GitHub Actions バージョン検索の Web UI & REST API
+
+- 最新バージョン＋フルコミット SHA をワンリクエストで取得
+- レート制限の心配なし — キャッシュ済みで高速
+- AI コーディングエージェント向け MCP サーバー（Claude Code、Cursor、Copilot 等）
+
+**[actver-dev/skills](https://github.com/actver-dev/skills)** — AI コーディングエージェント向けプラグイン＆スキル
+
+- **SHA ピン留め** — サプライチェーン攻撃からワークフローを保護
+- **Actions アップグレード** — 最新バージョンへ自動更新
+- **ワークフロー監査** — CI/CD パイプラインのセキュリティ問題を検出
+
+## クイックスタート
+
+### プラグインを使う（推奨）
+
+```bash
+# Claude Code
+claude plugin install actver-dev/skills
+
+# その他のエージェント（Cursor、Copilot 等）
+npx skills add actver-dev/skills
+```
+
+### MCP サーバーを使う
+
+`.mcp.json` に追加:
+
+```json
+{
+  "mcpServers": {
+    "actver": {
+      "type": "http",
+      "url": "https://actver.dev/mcp"
+    }
+  }
+}
+```
+
+### API を使う
+
+```bash
+curl https://actver.dev/v1/actions/actions/checkout
+```
+
+## サポート
+
+ActVer は無料サービスです。もしお役に立てたら:
+
+- [Buy Me a Coffee](https://buymeacoffee.com/yetanother_yk)
+- [GitHub Sponsors](https://github.com/sponsors/actver-dev)

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,64 @@
+# ActVer
+
+[日本語](README.ja.md)
+
+[![ActVer](https://img.shields.io/badge/ActVer-actver.dev-blue)](https://actver.dev)
+[![Buy Me a Coffee](https://img.shields.io/badge/Buy%20Me%20a%20Coffee-support-orange?logo=buy-me-a-coffee&logoColor=white)](https://buymeacoffee.com/yetanother_yk)
+
+**ActVer** is a free service that makes it easy to look up the latest GitHub Actions versions and commit SHAs — via REST API, MCP server, and web UI.
+
+Stop digging through release pages. Get the version you need in one request.
+
+## What We Offer
+
+**[actver.dev](https://actver.dev)** — Web UI & REST API for GitHub Actions version lookup
+
+- Get the latest version + full commit SHA with a single GET request
+- No rate-limit headaches — cached and fast
+- MCP server for AI coding agents (Claude Code, Cursor, Copilot, etc.)
+
+**[actver-dev/skills](https://github.com/actver-dev/skills)** — Plugin & skills for AI coding agents
+
+- **Pin actions to SHA** — secure your workflows against supply-chain attacks
+- **Upgrade actions** — bump to latest versions automatically
+- **Audit workflows** — detect security issues in your CI/CD pipelines
+
+## Quick Start
+
+### Use the Plugin (recommended)
+
+```bash
+# Claude Code
+claude plugin install actver-dev/skills
+
+# Other agents (Cursor, Copilot, etc.)
+npx skills add actver-dev/skills
+```
+
+### Use the MCP Server
+
+Add to your `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "actver": {
+      "type": "http",
+      "url": "https://actver.dev/mcp"
+    }
+  }
+}
+```
+
+### Use the API
+
+```bash
+curl https://actver.dev/v1/actions/actions/checkout
+```
+
+## Support
+
+ActVer is a free service. If you find it useful:
+
+- [Buy Me a Coffee](https://buymeacoffee.com/yetanother_yk)
+- [GitHub Sponsors](https://github.com/sponsors/actver-dev)


### PR DESCRIPTION
## Summary
- `profile/README.md`（英語）と `profile/README.ja.md`（日本語）を追加 — actver-dev org のプロフィールページに表示
- `README.md` を追加 — リポジトリ自体の説明
- `.github/FUNDING.yml` を追加 — org 全体のデフォルトスポンサー設定
- Ruleset によるブランチ保護、squash merge only、マージ後ブランチ自動削除を設定済み

## Test plan
- [ ] GitHub の actver-dev org プロフィールページで README が正しく表示されること
- [ ] 日本語版リンクが正しく動作すること
- [ ] バッジ（actver.dev, Buy Me a Coffee）が正しく表示されること
- [ ] FUNDING.yml のスポンサーボタンが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)