### PR TITLE
feat: セキュリティポリシーの追加と関連修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@
 | `profile/README.md` | org プロフィールページ（英語） |
 | `profile/README.ja.md` | org プロフィールページ（日本語） |
 | `.github/FUNDING.yml` | org 全体のデフォルトスポンサー設定 |
+| `SECURITY.md` | org 共通のセキュリティポリシー（英語 / 日本語） |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,77 @@
+# Security Policy
+
+[日本語](#セキュリティポリシー)
+
+## Supported Versions
+
+| Project | Supported |
+|---------|-----------|
+| [actver.dev](https://actver.dev) (API / MCP server) | :white_check_mark: |
+| [actver-dev/skills](https://github.com/actver-dev/skills) (Plugin & skills) | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Use [GitHub Security Advisories](https://github.com/actver-dev/.github/security/advisories/new) to report vulnerabilities privately.
+
+When reporting, please include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+## Response
+
+- We will acknowledge receipt within **72 hours**
+- We aim to provide an initial assessment within **1 week**
+- Critical vulnerabilities affecting the production service will be prioritized
+
+## Scope
+
+| In scope | Out of scope |
+|----------|--------------|
+| actver.dev API endpoints | Third-party dependencies (report upstream) |
+| MCP server (`/mcp`) | GitHub Actions themselves |
+| actver-dev/skills plugin | Theoretical attacks with no PoC |
+| Web UI (webapp) | |
+
+---
+
+# セキュリティポリシー
+
+## サポート対象バージョン
+
+| プロジェクト | サポート |
+|-------------|---------|
+| [actver.dev](https://actver.dev)（API / MCP サーバー） | :white_check_mark: |
+| [actver-dev/skills](https://github.com/actver-dev/skills)（プラグイン＆スキル） | :white_check_mark: |
+
+## 脆弱性の報告
+
+**セキュリティの脆弱性は公開 Issue で報告しないでください。**
+
+[GitHub Security Advisories](https://github.com/actver-dev/.github/security/advisories/new) からプライベートに報告してください。
+
+報告時に以下を含めてください:
+
+- 脆弱性の説明
+- 再現手順
+- 想定される影響
+- 修正案（あれば）
+
+## 対応方針
+
+- **72 時間以内**に受領を確認します
+- **1 週間以内**に初期評価を回答します
+- 本番サービスに影響する重大な脆弱性は優先的に対応します
+
+## 対象範囲
+
+| 対象 | 対象外 |
+|------|--------|
+| actver.dev API エンドポイント | サードパーティの依存関係（上流に報告してください） |
+| MCP サーバー (`/mcp`) | GitHub Actions 自体 |
+| actver-dev/skills プラグイン | PoC のない理論上の攻撃 |
+| Web UI（webapp） | |

--- a/profile/README.ja.md
+++ b/profile/README.ja.md
@@ -29,7 +29,8 @@
 
 ```bash
 # Claude Code
-claude plugin install actver-dev/skills
+claude plugin marketplace add actver-dev/skills
+claude plugin install actver
 
 # その他のエージェント（Cursor、Copilot 等）
 npx skills add actver-dev/skills

--- a/profile/README.md
+++ b/profile/README.md
@@ -29,7 +29,8 @@ Stop digging through release pages. Get the version you need in one request.
 
 ```bash
 # Claude Code
-claude plugin install actver-dev/skills
+claude plugin marketplace add actver-dev/skills
+claude plugin install actver
 
 # Other agents (Cursor, Copilot, etc.)
 npx skills add actver-dev/skills


### PR DESCRIPTION
## Summary
- `SECURITY.md` を追加 — 英語 / 日本語の二言語構成、GitHub Security Advisories での脆弱性報告を案内
- `README.md` のテーブルに SECURITY.md を追記
- `profile/README.md`, `profile/README.ja.md` のプラグインインストールコマンドを正しい2ステップ形式に修正

## API 経由で設定済み（このPR外）
- Private Vulnerability Reporting を `.github` / `skills` 両リポジトリで有効化
- Secret Scanning + Push Protection を `.github` / `skills` 両リポジトリで有効化

Closes #3

## Test plan
- [ ] SECURITY.md が GitHub の Security タブに表示されること
- [ ] actver-dev/skills リポジトリでも SECURITY.md がフォールバック表示されること
- [ ] Security Advisories の報告リンクが正しく動作すること
- [ ] プラグインインストールコマンドが正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)